### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eipm/bridge2ai-redcap/security/code-scanning/1](https://github.com/eipm/bridge2ai-redcap/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not perform any write operations and only triggers another workflow, the `GITHUB_TOKEN` permissions can be restricted to `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
